### PR TITLE
feat: 이메일 중복 체크 기능 추가

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/user/exception/DuplicateEmailException.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/exception/DuplicateEmailException.java
@@ -1,0 +1,9 @@
+package com.likelion.bd.domain.user.exception;
+
+import com.likelion.bd.global.exception.BaseException;
+
+public class DuplicateEmailException extends BaseException {
+    public DuplicateEmailException() {
+        super(UserErrorCode.USER_DUPLICATE_EMAIL_409);
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/domain/user/exception/UserErrorCode.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,16 @@
+package com.likelion.bd.domain.user.exception;
+
+import com.likelion.bd.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseResponseCode {
+
+    USER_DUPLICATE_EMAIL_409("USER_DUPLICATE_EMAIL_409", 409, "이미 존재하는 Email입니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/bd/src/main/java/com/likelion/bd/domain/user/repository/UserRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsByEmail(String email);
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
@@ -1,9 +1,13 @@
 package com.likelion.bd.domain.user.service;
 
+import com.likelion.bd.domain.user.web.dto.CheckEmailReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupRes;
 
 public interface UserService {
+
+    // 이메일 중복 체크 확인
+    void checkEmail(CheckEmailReq checkEmailReq);
 
     // 회원 가입
     UserSignupRes signup(UserSignupReq userSignupReq);

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
@@ -2,7 +2,9 @@ package com.likelion.bd.domain.user.service;
 
 import com.likelion.bd.domain.user.entity.User;
 import com.likelion.bd.domain.user.entity.UserRoleType;
+import com.likelion.bd.domain.user.exception.DuplicateEmailException;
 import com.likelion.bd.domain.user.repository.UserRepository;
+import com.likelion.bd.domain.user.web.dto.CheckEmailReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupRes;
 import com.likelion.bd.global.external.s3.S3Service;
@@ -19,9 +21,18 @@ public class UserServiceImpl implements UserService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final S3Service s3Service;
 
+    // 이메일 중복 검사
+    @Override
+    public void checkEmail(CheckEmailReq checkEmailReq) {
+        if (userRepository.existsByEmail(checkEmailReq.getEmail())) {
+            throw new DuplicateEmailException();
+        }
+    }
+
+    // 회원가입
     @Override
     @Transactional
-    public UserSignupRes signup(UserSignupReq userSignupReq) { // 회원가입
+    public UserSignupRes signup(UserSignupReq userSignupReq) {
 
         UserRoleType role = UserRoleType.valueOf(userSignupReq.getRole().toUpperCase());
 

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.likelion.bd.domain.user.web.controller;
 
 import com.likelion.bd.domain.user.service.UserService;
+import com.likelion.bd.domain.user.web.dto.CheckEmailReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupReq;
 import com.likelion.bd.domain.user.web.dto.UserSignupRes;
 import com.likelion.bd.global.response.SuccessResponse;
@@ -17,6 +18,19 @@ public class UserController {
 
     private final UserService userService;
 
+    // 이메일 중복 체크 확인
+    @PostMapping("/check-email")
+    public ResponseEntity<SuccessResponse<?>> check(
+            @RequestBody @Valid CheckEmailReq checkEmailReq
+    ) {
+        userService.checkEmail(checkEmailReq);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.emptyCustom("사용 가능한 이메일입니다."));
+    }
+
+    // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<?>> signup(
             @ModelAttribute @Valid UserSignupReq userSignupReq
@@ -27,6 +41,6 @@ public class UserController {
         // 반환
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(SuccessResponse.from(userSignupRes));
+                .body(SuccessResponse.ok(userSignupRes));
     }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/dto/CheckEmailReq.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/dto/CheckEmailReq.java
@@ -1,0 +1,15 @@
+package com.likelion.bd.domain.user.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckEmailReq {
+
+    @Email(message = "유효한 이메일 주소가 아닙니다.")
+    @NotBlank(message = "이메일은 필수 입력 값 입니다.")
+    private String email;
+}

--- a/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)  // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/user/signup").permitAll()
+                        .requestMatchers("/user/signup", "/user/check-email").permitAll()
                         .anyRequest().authenticated()  // 나머지는 인증 필요
                 );
 

--- a/bd/src/main/java/com/likelion/bd/global/response/SuccessResponse.java
+++ b/bd/src/main/java/com/likelion/bd/global/response/SuccessResponse.java
@@ -33,15 +33,15 @@ public class SuccessResponse<T>  extends BaseResponse {
         return new SuccessResponse<>(null, SuccessResponseCode.SUCCESS_OK);
     }
 
-    public static SuccessResponse<?> from(String message) { // data X, message 커스텀
+    public static SuccessResponse<?> emptyCustom (String message) { // data X, message 커스텀
         return new SuccessResponse<>(null, SuccessResponseCode.SUCCESS_OK, message);
     }
 
-    public static <T> SuccessResponse<T> from(T data) { // data 0, message 기본
+    public static <T> SuccessResponse<T> ok(T data) { // data 0, message 기본
         return new SuccessResponse<>(data, SuccessResponseCode.SUCCESS_OK);
     }
 
-    public static <T> SuccessResponse<T> of(T data, String message) { // data 0, message 커스텀
+    public static <T> SuccessResponse<T> okCustom(T data, String message) { // data 0, message 커스텀
         return new SuccessResponse<>(data, SuccessResponseCode.SUCCESS_OK, message);
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현

## 📝 작업 내용
- [x] 이메일 중복 체크
- [x] `SuccessResponse` 정적 팩토리 메서드 리팩토링

## 📎 참고 사항
- 메서드 이름을 `lowerCamelCase` 네이밍 컨벤션으로 수정

##  🖼️ 사진
<img width="334" height="144" alt="image" src="https://github.com/user-attachments/assets/c10bde9d-54e5-404d-b01d-db904827ebbe" />

<img width="700" height="295" alt="image" src="https://github.com/user-attachments/assets/6e0c0e68-b6f9-46fd-bd20-3e222575adee" />