### PR TITLE
develop에 JWT 토큰 기반 인증 기능 병합

### DIFF
--- a/bd/build.gradle
+++ b/bd/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.112'  // AWS S3 SDK 의존성 추가
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson 을 JSON 파서로 사용
 }
 
 tasks.named('test') {

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.likelion.bd.domain.user.exception.NotFoundEmailException;
 import com.likelion.bd.domain.user.repository.UserRepository;
 import com.likelion.bd.domain.user.web.dto.*;
 import com.likelion.bd.global.external.s3.S3Service;
+import com.likelion.bd.global.jwt.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,6 +22,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final S3Service s3Service;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 이메일 중복 검사
     @Override
@@ -85,6 +87,8 @@ public class UserServiceImpl implements UserService {
             throw new InvalidPasswordException();
         }
 
-        return new UserSigninRes(user.getUserId());
+        String token = jwtTokenProvider.createToken(user);
+
+        return new UserSigninRes(token);
     }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserSigninRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserSigninRes.java
@@ -1,5 +1,6 @@
 package com.likelion.bd.domain.user.web.dto;
 
-public record UserSigninRes(Long id) {
+public record UserSigninRes(
+        String token) {
 
 }

--- a/bd/src/main/java/com/likelion/bd/global/exception/CustomException.java
+++ b/bd/src/main/java/com/likelion/bd/global/exception/CustomException.java
@@ -1,17 +1,10 @@
 package com.likelion.bd.global.exception;
 
 import com.likelion.bd.global.response.code.BaseResponseCode;
-import com.likelion.bd.global.response.code.ErrorResponseCode;
 
-public class CustomException extends RuntimeException{
-    private final BaseResponseCode errorCode;
+public class CustomException extends BaseException {
 
     public CustomException(BaseResponseCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
-
-    public BaseResponseCode getErrorCode() {
-        return errorCode;
+        super(errorCode);
     }
 }

--- a/bd/src/main/java/com/likelion/bd/global/filter/JwtTokenFilter.java
+++ b/bd/src/main/java/com/likelion/bd/global/filter/JwtTokenFilter.java
@@ -1,0 +1,46 @@
+package com.likelion.bd.global.filter;
+
+import com.likelion.bd.global.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+// OncePerRequestFilter: 매 요청마다 한 번 실행되는 JWT 필터
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 요청이 들어올 때마다 JWT 토큰을 검증함
+    // 유효한 경우 인증 정보를 SecurityContext 에 저장
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 1. extractToken: Authorization 헤더에서 JWT 토큰 추출
+        String token = jwtTokenProvider.resolveToken(request);
+
+        // 2. validateToken: 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 3. getAuthentication: 토큰으로 사용자 인증 객체 생성!!
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            // 현재 요청의 SecurityContext 에 인증 정보 넣기
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/global/jwt/JwtTokenProvider.java
+++ b/bd/src/main/java/com/likelion/bd/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,147 @@
+package com.likelion.bd.global.jwt;
+
+import com.likelion.bd.domain.user.entity.User;
+import com.likelion.bd.global.exception.CustomException;
+import com.likelion.bd.global.response.code.AuthErrorResponseCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    // 헤더 이름과 접두사를 상수로 정의
+    private static final String HEADER = "Authorization";
+    private static final String PREFIX = "Bearer ";
+
+    private final Key key;
+    private final long validityInMilliseconds;
+    private final MyUserDetailsService userDetailsService;
+
+    public JwtTokenProvider(
+            @Value("${security.jwt.secret-key}") String secretKey,
+            @Value("${security.jwt.expiration}") long validityInMilliseconds,
+            MyUserDetailsService userDetailsService
+    ) {
+        // JWT 서명용 키 생성
+        // 1. secretKey 가 Base64 인코딩된 경우 → 디코딩하여 원본 바이트 추출
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+
+        // HMAC-SHA256 알고리즘에 사용할 Key 객체 생성
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+
+        this.validityInMilliseconds = validityInMilliseconds;
+        this.userDetailsService = userDetailsService;
+    }
+
+    /**
+     * 사용자 ID를 받아 JWT 토큰을 생성합니다.
+     * @param user 사용자
+     * @return 생성된 JWT 토큰 문자열
+     */
+    public String createToken(User user) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + this.validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getUserId()))  // 토큰의 주체(subject)로 사용자 ID를 문자열로 설정
+                .claim("role", user.getRole().name())       // 커스텀 클레임에 사용자 역할 추가
+                .setIssuedAt(now)                              // 발급 시각
+                .setExpiration(validity)                       // 만료 시각
+                .signWith(key)                                 // 준비된 key 를 사용하여 토큰을 서명 (알고리즘은 key 에 이미 포함됨)
+                .compact();                                    // 최종적으로 압축된 JWT 문자열을 생성
+    }
+
+    /**
+     * 토큰 문자열을 파싱하여 클레임(토큰에 담긴 정보)을 추출합니다.
+     * 서명 검증에 실패하거나 토큰이 유효하지 않으면 예외가 발생합니다.
+     * @param token JWT 토큰 문자열
+     * @return 토큰의 클레임 정보
+     */
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key) // 서명 검증에 사용할 키를 설정합니다.
+                .build()
+                .parseClaimsJws(token) // 토큰을 파싱하고 서명을 검증합니다.
+                // 서명 검증, 만료 시간, 형식 검증, 다양한 기본적인 검사들 수행
+                .getBody(); // Payload(Claims) 부분을 반환합니다.
+    }
+
+    /**
+     * HTTP 요청의 헤더에서 Bearer 토큰을 추출합니다.
+     * @param request HttpServletRequest 객체
+     * @return 추출된 JWT 문자열 또는 토큰이 없을 경우 null
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX)) {
+            // StringUtils.hasText(bearerToken) : null, "", "   " (공백만 있는 문자열)까지 모두 false 처리
+            // bearerToken.startsWith(PREFIX) : 헤더 값이 지정한 접두어(PREFIX, "Bearer ")로 시작하는지 확인
+            return bearerToken.substring(PREFIX.length());
+        }
+        return null;
+    }
+
+    /**
+     * 토큰이 유효한지 검증하는 메서드
+     * @param token 검증할 JWT 토큰
+     * @return 토큰이 유효하면 true, 아니면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            // getClaims 가 내부적으로 토큰을 파싱하고 서명을 검증합니다.
+            // 유효하지 않으면 예외가 발생하므로, catch 블록으로 잡힙니다.
+            getClaims(token);
+            return true;
+        } catch (SignatureException e) {
+            log.error("유효하지 않은 JWT 서명입니다: {}", e.getMessage());
+            throw new CustomException(AuthErrorResponseCode.INVALID_SIGNATURE);
+        } catch (MalformedJwtException e) {
+            log.error("잘못된 형식의 JWT 토큰입니다: {}", e.getMessage());
+            throw new CustomException(AuthErrorResponseCode.MALFORMED_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다: {}", e.getMessage());
+            throw new CustomException(AuthErrorResponseCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.error("지원하지 않는 JWT 토큰입니다: {}", e.getMessage());
+            throw new CustomException(AuthErrorResponseCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 클레임 문자열이 비어있습니다: {}", e.getMessage());
+            throw new CustomException(AuthErrorResponseCode.ILLEGAL_ARGUMENT);
+        }
+    }
+
+    /**
+     * JWT 토큰을 복호화하여 토큰에 들어있는 정보를 기반으로 Authentication 객체를 반환합니다.
+     * 데이터베이스에서 사용자 정보를 조회하여 SecurityContext 에 저장할 완전한 형태의 인증 객체를 생성합니다.
+     * @param token JWT 토큰
+     * @return 사용자 정보를 담은 Authentication 객체
+     */
+    public Authentication getAuthentication(String token) {
+        // 토큰에서 클레임(정보) 추출
+        Claims claims = getClaims(token);
+
+        // 클레임에서 사용자 ID(Subject) 추출
+        String userId = claims.getSubject();
+
+        // 사용자 ID를 기반으로 데이터베이스에서 UserDetails 객체 조회
+        // 이 UserDetails 는 사용자의 아이디, 패스워드, 권한 등을 담고 있는 Spring Security 의 표준 인터페이스
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+
+        // UserDetails 객체, 비밀번호(보통 null 처리), 권한 정보를 기반으로 Authentication 객체 생성
+        // 이 객체는 Spring Security 가 내부적으로 사용자의 인증 상태를 관리하는 데 사용됩니다.
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/global/jwt/MyUserDetailsService.java
+++ b/bd/src/main/java/com/likelion/bd/global/jwt/MyUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.likelion.bd.global.jwt;
+
+import com.likelion.bd.domain.user.entity.User;
+import com.likelion.bd.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+
+        // DB 에서 사용자 정보 조회
+        User user = userRepository.getById(Long.parseLong(userId));
+        // 조회한 User 객체 전체를 UserPrincipal 로 감싸서 반환
+        return new UserPrincipal(user);
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/global/jwt/UserPrincipal.java
+++ b/bd/src/main/java/com/likelion/bd/global/jwt/UserPrincipal.java
@@ -1,0 +1,62 @@
+package com.likelion.bd.global.jwt;
+
+import com.likelion.bd.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class UserPrincipal implements UserDetails {
+
+    private final Long id;
+    private final String role; // "USER" or "ROLE_USER" 형태로 저장
+
+    UserPrincipal(User user) {
+        this.id = user.getUserId();
+        this.role = user.getRole().name();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        String role = this.role.startsWith("ROLE_") ? this.role : "ROLE_" + this.role;
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    @Override
+    public String getPassword() {
+        // JWT 인증에서는 비밀번호를 사용하지 않으므로 null 반환
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        // 사용자를 식별하는 고유한 값 (여기서는 ID)을 문자열로 반환합니다.
+        return String.valueOf(id);
+    }
+
+    // --- 계정 상태 관련 메서드들 (특별한 로직이 없다면 모두 true 반환) ---
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 계정이 만료되지 않았음
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 계정이 잠기지 않았음
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // 자격 증명(비밀번호)이 만료되지 않았음
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true; // 계정이 활성화됨
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/global/response/code/AuthErrorResponseCode.java
+++ b/bd/src/main/java/com/likelion/bd/global/response/code/AuthErrorResponseCode.java
@@ -1,0 +1,22 @@
+package com.likelion.bd.global.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.bd.global.constant.StaticValue.UNAUTHORIZED;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorResponseCode implements BaseResponseCode {
+
+    AUTHENTICATION_FAILED("AUTHENTICATION_FAILED", UNAUTHORIZED, "로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해 주세요."),
+    INVALID_SIGNATURE("INVALID_SIGNATURE", 401, "유효하지 않은 JWT 서명입니다."),
+    MALFORMED_TOKEN("MALFORMED_TOKEN", 401, "잘못된 형식의 JWT 토큰입니다."),
+    EXPIRED_TOKEN("EXPIRED_TOKEN", 401, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_TOKEN("UNSUPPORTED_TOKEN", 401, "지원하지 않는 JWT 토큰입니다."),
+    ILLEGAL_ARGUMENT("ILLEGAL_ARGUMENT", 401, "JWT 클레임 문자열이 비어있습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/bd/src/main/resources/application.properties
+++ b/bd/src/main/resources/application.properties
@@ -22,3 +22,8 @@ cloud.aws.stack.auto=false
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.credentials.access-key=${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
+
+# JWT
+security.jwt.secret-key=${JWT_SECRET_KEY}
+    # 1일
+security.jwt.expiration=${JWT_EXPIRATION}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- Spring Security와 JWT를 연동하여 토큰 기반의 인증 시스템을 구축

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] JWT 토큰 생성/검증 로직 구현
- [x] JWT 필터 추가
- [x] SecurityConfig에 JWT 필터 등록 및 경로 설정
- [x] 로그인 API 수정(토큰 발급)
- [x] JWT 관련 커스텀 예외 처리

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->
- `@Transactional`을 사용한 LazyInitializationException 해결
  - 문제 원인: MyUserDetailsService의 loadUserByUsername 메서드에서 LazyInitializationException이 발생했습니다. 이는 JPA의 지연 로딩(Lazy Loading) 전략 때문입니다.
    - userRepository.findById()를 호출하면, JPA는 성능을 위해 실제 User 데이터가 아닌 프록시(Proxy) 객체를 먼저 반환합니다.
    User와 연관된 필드(예: role)의 데이터는 실제로 해당 필드에 접근(user.getRole())하는 시점에 추가로 조회됩니다.
    하지만 `@Transactional`이 없으면, findById() 호출 직후 데이터베이스와의 연결(세션)이 바로 닫혀버립니다.
    결과적으로, 이후 new UserPrincipal(user)에서 user.getRole()을 호출할 때 이미 세션이 끊겨있어 데이터를 가져오지 못하고 예외가 발생한 것입니다.

  - 해결 방법: 이 문제를 해결하기 위해 loadUserByUsername 메서드에 `@Transactional(readOnly = true)` 어노테이션을 추가했습니다.
    - `@Transactional`은 메서드가 시작될 때 세션을 열고, 메서드가 완전히 종료될 때 세션을 닫도록 세션의 생명주기를 확장해 줍니다.
    덕분에 user.getRole()을 호출하는 시점에도 세션이 유지되어, 지연 로딩된 데이터를 성공적으로 조회할 수 있습니다.
    readOnly = true 옵션은 이 트랜잭션이 데이터 변경 없이 오직 읽기 전용임을 명시하여, 불필요한 기능(변경 감지 등)을 비활성화하는 성능 최적화 효과를 가져옵니다.

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="334" height="227" alt="image" src="https://github.com/user-attachments/assets/71131237-8e24-4b7a-82b3-d23033300ca8" />