### PR TITLE
feat: 인플루언서 활동 정보 저장 기능

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
@@ -42,6 +42,12 @@ public class Activity extends BaseEntity {
 
     @Column(name = "ACCOUNT_NUMBER", nullable = false)
     private String accountNumber; // 계좌번호
+
+    @Column(name = "MIN_AMOUNT", nullable = false)
+    private Long minAmount; // 최소 희망 금액
+
+    @Column(name = "MAX_AMOUNT", nullable = false)
+    private Long maxAmount; // 최대 희망 금액
 }
 
 

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
@@ -7,6 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -18,10 +21,6 @@ public class Activity extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ACTIVITY_ID")
     private Long activityId;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "INFLUENCER_ID", nullable = false)
-    private Influencer influencer;
 
     @Column(name = "ACTIVITY_NAME", nullable = false)
     private String activityName; // 활동명
@@ -48,6 +47,24 @@ public class Activity extends BaseEntity {
 
     @Column(name = "MAX_AMOUNT", nullable = false)
     private Long maxAmount; // 최대 희망 금액
+
+    // -------------------------------------------------------------------------------------
+
+    @Builder.Default
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityPlatform> activityPlatformList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityContentTopic> activityContentTopicList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityContentStyle> activityContentStyleList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityPreferTopic> activityPreferTopicList = new ArrayList<>();
 }
 
 

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
@@ -65,6 +65,28 @@ public class Activity extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ActivityPreferTopic> activityPreferTopicList = new ArrayList<>();
+
+    // -------------------------------------------------------------------------------------
+
+    public void addActivityPlatform(ActivityPlatform activityPlatform) {
+        this.activityPlatformList.add(activityPlatform);
+        activityPlatform.setActivity(this);
+    }
+
+    public void addActivityContentTopic(ActivityContentTopic activityContentTopic) {
+        this.activityContentTopicList.add(activityContentTopic);
+        activityContentTopic.setActivity(this);
+    }
+
+    public void addActivityContentStyle(ActivityContentStyle activityContentStyle) {
+        this.activityContentStyleList.add(activityContentStyle);
+        activityContentStyle.setActivity(this);
+    }
+
+    public void addActivityPreferTopic(ActivityPreferTopic activityPreferTopic) {
+        this.activityPreferTopicList.add(activityPreferTopic);
+        activityPreferTopic.setActivity(this);
+    }
 }
 
 

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Activity.java
@@ -23,17 +23,25 @@ public class Activity extends BaseEntity {
     @JoinColumn(name = "INFLUENCER_ID", nullable = false)
     private Influencer influencer;
 
-    @Column(name = "SNS_URL", nullable = false)
-    private String snsUrl; // SNS 주소
-
-    @Column(name = "FOLLOWER_COUNT", nullable = false)
-    private Long followerCount; // 팔로워 수
-
     @Column(name = "ACTIVITY_NAME", nullable = false)
     private String activityName; // 활동명
 
-    @Column(name = "ACCOUNT", nullable = false)
-    private String account; // 계좌
+    @Column(name = "SNS_URL", nullable = false)
+    private String snsUrl; // SNS 주소
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "FOLLOWER_COUNT_RANGE", nullable = false)
+    private FollowerCountRange followerCountRange; // 팔로워 수 범위
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "UPLOAD_FREQUENCY", nullable = false)
+    private UploadFrequency uploadFrequency; // 주 업로드 횟수
+
+    @Column(name = "BANKNAME", nullable = false)
+    private String bankName; // 은행명
+
+    @Column(name = "ACCOUNT_NUMBER", nullable = false)
+    private String accountNumber; // 계좌번호
 }
 
 

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentStyle.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentStyle.java
@@ -1,13 +1,11 @@
 package com.likelion.bd.domain.influencer.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentTopic.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentTopic.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "activity_contnetTopic")
+@Table(name = "activity_contentTopic")
 public class ActivityContentTopic {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentTopic.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityContentTopic.java
@@ -1,13 +1,11 @@
 package com.likelion.bd.domain.influencer.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPlatform.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPlatform.java
@@ -1,13 +1,11 @@
 package com.likelion.bd.domain.influencer.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPreferTopic.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPreferTopic.java
@@ -1,13 +1,11 @@
 package com.likelion.bd.domain.influencer.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPreferTopic.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/ActivityPreferTopic.java
@@ -1,0 +1,27 @@
+package com.likelion.bd.domain.influencer.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "activity_preferTopic")
+public class ActivityPreferTopic {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ACTIVITY_ID", nullable = false)
+    private Activity activity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CONTENTTOPIC_ID", nullable = false)
+    private PreferTopic preferTopic;
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/FollowerCountRange.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/FollowerCountRange.java
@@ -1,0 +1,10 @@
+package com.likelion.bd.domain.influencer.entity;
+
+public enum FollowerCountRange {
+
+    LESS_THAN_1K, // 1천 미만
+    BETWEEN_1K_AND_5K, // 1천 ~ 5천
+    BETWEEN_5K_AND_10K, // 5천 ~ 1만
+    BETWEEN_10K_AND_100K, // 1만 ~ 10만
+    OVER_100K; // 10만 이상
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/FollowerCountRange.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/FollowerCountRange.java
@@ -7,4 +7,14 @@ public enum FollowerCountRange {
     BETWEEN_5K_AND_10K, // 5천 ~ 1만
     BETWEEN_10K_AND_100K, // 1만 ~ 10만
     OVER_100K; // 10만 이상
+
+    public static FollowerCountRange fromValue(int value) {
+        int index = value - 1;
+        FollowerCountRange[] ranges = values();
+
+        if (index >= 0 && index < ranges.length) {
+            return ranges[index];
+        }
+        throw new IllegalArgumentException("유효하지 않은 팔로워 수 범위 값입니다: " + value);
+    }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/PreferTopic.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/PreferTopic.java
@@ -1,0 +1,23 @@
+package com.likelion.bd.domain.influencer.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "preferTopic")
+public class PreferTopic {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PREFERTOPIC_ID")
+    private Long preferTopicId;
+
+    @Column(name = "NAME", nullable = false)
+    private String name; // 선호 분야 이름
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/UploadFrequency.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/UploadFrequency.java
@@ -6,5 +6,15 @@ public enum UploadFrequency {
     ONCE_OR_TWICE, // 1회 ~ 2회
     THREE_OR_FOUR_TIMES, // 3회 ~ 4회
     FIVE_OR_SIX_TIMES, // 5회 ~ 6회
-    SEVEN_TIMES // 7회
+    SEVEN_TIMES; // 7회
+
+    public static UploadFrequency fromValue(int value) {
+        int index = value - 1;
+        UploadFrequency[] frequencies = values();
+
+        if (index >= 0 && index < frequencies.length) {
+            return frequencies[index];
+        }
+        throw new IllegalArgumentException("유효하지 않은 업로드 횟수 값입니다: " + value);
+    }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/UploadFrequency.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/UploadFrequency.java
@@ -1,0 +1,10 @@
+package com.likelion.bd.domain.influencer.entity;
+
+public enum UploadFrequency {
+
+    LESS_THAN_ONCE, // 1회 미만
+    ONCE_OR_TWICE, // 1회 ~ 2회
+    THREE_OR_FOUR_TIMES, // 3회 ~ 4회
+    FIVE_OR_SIX_TIMES, // 5회 ~ 6회
+    SEVEN_TIMES // 7회
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ActivityRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ActivityRepository.java
@@ -1,0 +1,7 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ContentStyleRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ContentStyleRepository.java
@@ -1,0 +1,10 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.ContentStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentStyleRepository extends JpaRepository<ContentStyle, Long> {
+
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ContentTopicRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/ContentTopicRepository.java
@@ -1,0 +1,10 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.ContentTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContentTopicRepository extends JpaRepository<ContentTopic, Long> {
+
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/InfluencerRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/InfluencerRepository.java
@@ -1,0 +1,7 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.Influencer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfluencerRepository extends JpaRepository<Influencer, Long> {
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/PlatformRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/PlatformRepository.java
@@ -1,0 +1,10 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.Platform;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlatformRepository extends JpaRepository<Platform, Long> {
+
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/PreferTopicRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/PreferTopicRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.bd.domain.influencer.repository;
+
+import com.likelion.bd.domain.influencer.entity.PreferTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PreferTopicRepository extends JpaRepository<PreferTopic, Long> {
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerService.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerService.java
@@ -1,0 +1,9 @@
+package com.likelion.bd.domain.influencer.service;
+
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateReq;
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateRes;
+
+public interface InfluencerService {
+
+    ActivityCreateRes createActivity(ActivityCreateReq activityCreateReq, Long userId);
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
@@ -1,0 +1,116 @@
+package com.likelion.bd.domain.influencer.service;
+
+import com.likelion.bd.domain.influencer.entity.*;
+import com.likelion.bd.domain.influencer.repository.*;
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateReq;
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateRes;
+import com.likelion.bd.domain.user.entity.User;
+import com.likelion.bd.domain.user.repository.UserRepository;
+import com.likelion.bd.global.exception.CustomException;
+import com.likelion.bd.global.response.code.Influencer.ActivityErrorCode;
+import com.likelion.bd.global.response.code.UserErrorResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InfluencerServiceImpl implements InfluencerService {
+
+    private final UserRepository userRepository;
+    private final InfluencerRepository influencerRepository;
+    private final ActivityRepository activityRepository;
+    private final PlatformRepository platformRepository;
+    private final ContentTopicRepository contentTopicRepository;
+    private final ContentStyleRepository contentStyleRepository;
+    private final PreferTopicRepository preferTopicRepository;
+
+    @Override
+    @Transactional
+    public ActivityCreateRes createActivity(
+            ActivityCreateReq activityCreateReq,
+            Long userId
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorResponseCode.USER_NOT_FOUND_404));
+
+        // -------------------------------------------------------------------------------------------------------
+
+        Activity activity = Activity.builder() // 유효성 검사를 다 통과하고 넘어왔다는 가정
+                .activityName(activityCreateReq.getActivityName())
+                .snsUrl(activityCreateReq.getSnsUrl())
+                .followerCountRange(FollowerCountRange.fromValue(activityCreateReq.getFollowerCountRange()))
+                .uploadFrequency(UploadFrequency.fromValue(activityCreateReq.getUploadFrequency()))
+                .bankName(activityCreateReq.getBankName())
+                .accountNumber(activityCreateReq.getAccountNumber())
+                .minAmount(activityCreateReq.getMinAmount())
+                .maxAmount(activityCreateReq.getMaxAmount())
+                .build();
+        activityRepository.save(activity);
+
+        // -------------------------------------------------------------------------------------------------------
+
+        Influencer influencer = Influencer.builder()
+                .user(user)
+                .activity(activity)
+                .build();
+        influencerRepository.save(influencer);
+
+        // -------------------------------------------------------------------------------------------------------
+
+        for (Long platformId : activityCreateReq.getPlatformIds()) {
+            Platform platform = platformRepository.findById(platformId)
+                    .orElseThrow(() -> new CustomException(ActivityErrorCode.PLATFORM_NOT_FOUND_404));
+
+            ActivityPlatform ap = ActivityPlatform.builder()
+                    .activity(activity)
+                    .platform(platform)
+                    .build();
+
+            activity.getActivityPlatformList().add(ap);
+        }
+
+        for (Long contentTopicId : activityCreateReq.getContentTopicIds()) {
+            ContentTopic contentTopic = contentTopicRepository.findById(contentTopicId)
+                    .orElseThrow(() -> new CustomException(ActivityErrorCode.CONTENTTOPIC_NOT_FOUND_404));
+
+            ActivityContentTopic act = ActivityContentTopic.builder()
+                    .activity(activity)
+                    .contentTopic(contentTopic)
+                    .build();
+
+            activity.getActivityContentTopicList().add(act);
+        }
+
+        for (Long contentStyleId : activityCreateReq.getContentStyleIds()) {
+            ContentStyle contentStyle = contentStyleRepository.findById(contentStyleId)
+                    .orElseThrow(() -> new CustomException(ActivityErrorCode.CONTENTSTYLE_NOT_FOUND_404));
+
+            ActivityContentStyle acs = ActivityContentStyle.builder()
+                    .activity(activity)
+                    .contentStyle(contentStyle)
+                    .build();
+
+            activity.getActivityContentStyleList().add(acs);
+        }
+
+        for (Long preferTopicId : activityCreateReq.getPreferTopicIds()) {
+            PreferTopic preferTopic = preferTopicRepository.findById(preferTopicId)
+                    .orElseThrow(() -> new CustomException(ActivityErrorCode.PREPERTOPIC_NOT_FOUND_404));
+
+            ActivityPreferTopic apt = ActivityPreferTopic.builder()
+                    .activity(activity)
+                    .preferTopic(preferTopic)
+                    .build();
+
+            activity.getActivityPreferTopicList().add(apt);
+        }
+
+        activityRepository.save(activity);
+        // -------------------------------------------------------------------------------------------------------
+
+        return new ActivityCreateRes(
+                influencer.getInfluencerId()
+        );
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
@@ -50,14 +50,6 @@ public class InfluencerServiceImpl implements InfluencerService {
 
         // -------------------------------------------------------------------------------------------------------
 
-        Influencer influencer = Influencer.builder()
-                .user(user)
-                .activity(activity)
-                .build();
-        influencerRepository.save(influencer);
-
-        // -------------------------------------------------------------------------------------------------------
-
         for (Long platformId : activityCreateReq.getPlatformIds()) {
             Platform platform = platformRepository.findById(platformId)
                     .orElseThrow(() -> new CustomException(ActivityErrorCode.PLATFORM_NOT_FOUND_404));
@@ -67,7 +59,7 @@ public class InfluencerServiceImpl implements InfluencerService {
                     .platform(platform)
                     .build();
 
-            activity.getActivityPlatformList().add(ap);
+            activity.addActivityPlatform(ap);
         }
 
         for (Long contentTopicId : activityCreateReq.getContentTopicIds()) {
@@ -79,7 +71,7 @@ public class InfluencerServiceImpl implements InfluencerService {
                     .contentTopic(contentTopic)
                     .build();
 
-            activity.getActivityContentTopicList().add(act);
+            activity.addActivityContentTopic(act);
         }
 
         for (Long contentStyleId : activityCreateReq.getContentStyleIds()) {
@@ -91,7 +83,7 @@ public class InfluencerServiceImpl implements InfluencerService {
                     .contentStyle(contentStyle)
                     .build();
 
-            activity.getActivityContentStyleList().add(acs);
+            activity.addActivityContentStyle(acs);
         }
 
         for (Long preferTopicId : activityCreateReq.getPreferTopicIds()) {
@@ -103,10 +95,18 @@ public class InfluencerServiceImpl implements InfluencerService {
                     .preferTopic(preferTopic)
                     .build();
 
-            activity.getActivityPreferTopicList().add(apt);
+            activity.addActivityPreferTopic(apt);
         }
 
         activityRepository.save(activity);
+        // -------------------------------------------------------------------------------------------------------
+
+        Influencer influencer = Influencer.builder()
+                .user(user)
+                .activity(activity)
+                .build();
+        influencerRepository.save(influencer);
+
         // -------------------------------------------------------------------------------------------------------
 
         return new ActivityCreateRes(

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/web/controller/InfluencerController.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/web/controller/InfluencerController.java
@@ -1,0 +1,34 @@
+package com.likelion.bd.domain.influencer.web.controller;
+
+import com.likelion.bd.domain.influencer.service.InfluencerService;
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateReq;
+import com.likelion.bd.domain.influencer.web.dto.ActivityCreateRes;
+import com.likelion.bd.global.jwt.UserPrincipal;
+import com.likelion.bd.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/influencer")
+public class InfluencerController {
+
+    private final InfluencerService influencerService;
+
+    @PostMapping("/create")
+    public ResponseEntity<SuccessResponse<?>> createActivity(
+            @RequestBody @Valid ActivityCreateReq activityCreateReq,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+
+        ActivityCreateRes activityCreateRes = influencerService.createActivity(activityCreateReq, userPrincipal.getId());
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.ok(activityCreateRes));
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/ActivityCreateReq.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/ActivityCreateReq.java
@@ -1,0 +1,56 @@
+package com.likelion.bd.domain.influencer.web.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ActivityCreateReq {
+
+    @NotBlank(message = "활동명은 필수 입력 항목입니다.")
+    private String activityName; // 활동명
+
+    @NotBlank(message = "SNS 주소는 필수 입력 항목입니다.")
+    @URL(message = "유효한 URL 형식이 아닙니다.")
+    private String snsUrl; // sns 주소
+
+    @NotNull(message = "팔로워 수 범위를 선택해주세요.")
+    @Min(value = 1, message = "팔로워 수 범위는 1에서 5 사이의 값이어야 합니다.")
+    @Max(value = 5, message = "팔로워 수 범위는 1에서 5 사이의 값이어야 합니다.")
+    int followerCountRange; // 팔로워 수 범위
+
+    @NotNull(message = "주 업로드 횟수를 선택해주세요.")
+    @Min(value = 1, message = "주 업로드 횟수는 1에서 5 사이의 값이어야 합니다.")
+    @Max(value = 5, message = "주 업로드 횟수는 1에서 5 사이의 값이어야 합니다.")
+    int uploadFrequency; // 주 업로드 횟수
+
+    @NotBlank(message = "은행명은 필수 입력 항목입니다.")
+    private String bankName; // 은행명
+
+    @NotBlank(message = "계좌번호는 필수 입력 항목입니다.")
+    private String accountNumber; // 계좌 번호
+
+    @PositiveOrZero(message = "최소 희망 금액은 0 이상이어야 합니다.")
+    private Long minAmount; // 최소 희망 금액
+
+    @PositiveOrZero(message = "최대 희망 금액은 0 이상이어야 합니다.")
+    private Long maxAmount; // 최대 희망 금액
+
+    @NotEmpty(message = "플랫폼을 하나 이상 선택해주세요.")
+    private List<Long> platformIds; // 활동 플랫폼 카테고리
+
+    @NotEmpty(message = "콘텐츠 분야를 하나 이상 선택해주세요.")
+    private List<Long> contentTopicIds; // 콘텐츠 분야
+
+    @NotEmpty(message = "콘텐츠 스타일을 하나 이상 선택해주세요.")
+    private List<Long> contentStyleIds; // 콘텐츠 스타일
+
+    @NotEmpty(message = "선호 분야를 하나 이상 선택해주세요.")
+    private List<Long> preferTopicIds; // 선호 분야
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/ActivityCreateRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/ActivityCreateRes.java
@@ -1,0 +1,6 @@
+package com.likelion.bd.domain.influencer.web.dto;
+
+public record ActivityCreateRes(
+        Long influencerId
+) {
+}

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
@@ -49,7 +49,7 @@ public class UserServiceImpl implements UserService {
 
         // s3에 저장된 이미지 url 받아오기
         String imageUrl = null;
-        if (userSignupReq.getProfileImage() != null) {
+        if (userSignupReq.getProfileImage() != null && !userSignupReq.getProfileImage().isEmpty()) {
             imageUrl = s3Service.uploadImageToS3(userSignupReq.getProfileImage());
         }
 

--- a/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
 
                         .requestMatchers("/user/signup", "/user/signin",
                                 "/user/check-email", "/user/check-nickname").permitAll()
+                        .requestMatchers("/influencer/create").hasRole("INFLUENCER")
 //                        .requestMatchers("/api/").permitAll()
 //                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()  // 그 외 요청은 전부 토큰 필요

--- a/bd/src/main/java/com/likelion/bd/global/init/DataInitializer.java
+++ b/bd/src/main/java/com/likelion/bd/global/init/DataInitializer.java
@@ -3,9 +3,11 @@ package com.likelion.bd.global.init;
 import com.likelion.bd.domain.influencer.entity.ContentStyle;
 import com.likelion.bd.domain.influencer.entity.ContentTopic;
 import com.likelion.bd.domain.influencer.entity.Platform;
+import com.likelion.bd.domain.influencer.entity.PreferTopic;
 import com.likelion.bd.domain.influencer.repository.ContentStyleRepository;
 import com.likelion.bd.domain.influencer.repository.ContentTopicRepository;
 import com.likelion.bd.domain.influencer.repository.PlatformRepository;
+import com.likelion.bd.domain.influencer.repository.PreferTopicRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -22,6 +24,7 @@ public class DataInitializer implements ApplicationRunner {
     private final PlatformRepository platformRepository;
     private final ContentTopicRepository contentTopicRepository;
     private final ContentStyleRepository contentStyleRepository;
+    private final PreferTopicRepository preferTopicRepository;
 
     @Override
     @Transactional
@@ -58,6 +61,18 @@ public class DataInitializer implements ApplicationRunner {
             styleNames.forEach(name -> {
                 ContentStyle style = ContentStyle.builder().name(name).build();
                 contentStyleRepository.save(style);
+            });
+        }
+
+        // 선호 분야 데이터 초기화
+        if (preferTopicRepository.count() == 0) {
+            List<String> industryNames = Arrays.asList(
+                    "음식/음료", "쇼핑/소매", "반려동물", "뷰티/서비스",
+                    "운동/건강", "문화/체험", "콘텐츠", "기타"
+            );
+            industryNames.forEach(name -> {
+                PreferTopic topic = PreferTopic.builder().name(name).build();
+                preferTopicRepository.save(topic);
             });
         }
     }

--- a/bd/src/main/java/com/likelion/bd/global/init/DataInitializer.java
+++ b/bd/src/main/java/com/likelion/bd/global/init/DataInitializer.java
@@ -1,0 +1,64 @@
+package com.likelion.bd.global.init;
+
+import com.likelion.bd.domain.influencer.entity.ContentStyle;
+import com.likelion.bd.domain.influencer.entity.ContentTopic;
+import com.likelion.bd.domain.influencer.entity.Platform;
+import com.likelion.bd.domain.influencer.repository.ContentStyleRepository;
+import com.likelion.bd.domain.influencer.repository.ContentTopicRepository;
+import com.likelion.bd.domain.influencer.repository.PlatformRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final PlatformRepository platformRepository;
+    private final ContentTopicRepository contentTopicRepository;
+    private final ContentStyleRepository contentStyleRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) throws Exception {
+        // 활동 플랫폼 데이터 초기화
+        if (platformRepository.count() == 0) {
+            List<String> platformNames = Arrays.asList(
+                    "인스타그램", "유튜브", "블로그", "틱톡", "릴스", "쇼츠", "페이스북", "기타"
+            );
+            platformNames.forEach(name -> {
+                Platform platform = Platform.builder().name(name).build();
+                platformRepository.save(platform);
+            });
+        }
+
+        // 콘텐츠 분야 데이터 초기화
+        if (contentTopicRepository.count() == 0) {
+            List<String> topicNames = Arrays.asList(
+                    "음식/카페", "뷰티", "패션", "헬스/피트니스", "키즈", "교육/정보",
+                    "VLOG", "게임/IT", "반려동물", "영화/드라마", "음악/댄스", "기타"
+            );
+            topicNames.forEach(name -> {
+                ContentTopic topic = ContentTopic.builder().name(name).build();
+                contentTopicRepository.save(topic);
+            });
+        }
+
+        // 콘텐츠 스타일 데이터 초기화
+        if (contentStyleRepository.count() == 0) {
+            List<String> styleNames = Arrays.asList(
+                    "정보전달형", "유머/유쾌 중심", "감정 중심형", "전문가형",
+                    "예술적/감각적", "도전/이벤트형", "트렌디한", "일상 공유형", "기타"
+            );
+            styleNames.forEach(name -> {
+                ContentStyle style = ContentStyle.builder().name(name).build();
+                contentStyleRepository.save(style);
+            });
+        }
+    }
+}

--- a/bd/src/main/java/com/likelion/bd/global/jwt/UserPrincipal.java
+++ b/bd/src/main/java/com/likelion/bd/global/jwt/UserPrincipal.java
@@ -1,6 +1,7 @@
 package com.likelion.bd.global.jwt;
 
 import com.likelion.bd.domain.user.entity.User;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -9,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
+@Getter // 토큰에서 userId 를 가져오기 위한 어노테이션
 @RequiredArgsConstructor
 public class UserPrincipal implements UserDetails {
 

--- a/bd/src/main/java/com/likelion/bd/global/response/code/Influencer/ActivityErrorCode.java
+++ b/bd/src/main/java/com/likelion/bd/global/response/code/Influencer/ActivityErrorCode.java
@@ -1,0 +1,19 @@
+package com.likelion.bd.global.response.code.Influencer;
+
+import com.likelion.bd.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ActivityErrorCode implements BaseResponseCode {
+
+    PLATFORM_NOT_FOUND_404("PLATFORM_NOT_FOUND_404",404,"해당 플랫폼이 존재하지 않습니다."),
+    CONTENTTOPIC_NOT_FOUND_404("CONTENTTOPIC_NOT_FOUND_404",404,"해당 콘텐츠 분야가 존재하지 않습니다."),
+    CONTENTSTYLE_NOT_FOUND_404("CONTENTSTYLE_NOT_FOUND_404",404,"해당 콘텐스 스타일이 존재하지 않습니다."),
+    PREPERTOPIC_NOT_FOUND_404("PREPERTOPIC_NOT_FOUND_404",404,"해당 선호 분야가 존재하지 않습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 인플루언서 회원가입 시 활동 정보들을 저장하는 기능을 구현

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] 활동 등록 관련 DTO 및 커스텀 예외 클래스 설계
- [x] JPA 엔티티 양방향 연관관계 설정 및 편의 메서드 구현
- [x] 활동 등록 자격 확인 
- [x] 활동 정보 생성 및 저장

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->
- `@Builder`와 컬렉션 초기화의 함정
  - 엔티티에서 `@Builder`를 사용할 때, List 같은 컬렉션 필드는 자동으로 초기화되지 않아 null이 되는 문제
  이 상태에서 `.add()`를 호출하면 **NullPointerException이 발생**
  ➡️ 해결: `@Builder.Default` 어노테이션과 함께 명시적으로 초기화하여 문제를 해결
    ```java
    @Builder.Default
    private List<ActivityPlatform> activityPlatformList = new ArrayList<>();
    ```

- ApplicationRunner를 이용한 초기 데이터 적재
  -  서버가 시작될 때, 사용자가 활동 정보를 등록하는 데 꼭 필요한 기초 데이터들(예: 플랫폼 종류, 콘텐츠 분야 등)을 데이터베이스에 미리 자동으로 생성하기 위해 ApplicationRunner를 구현
  - **구현 이유**
    - 이 기능이 없다면, 모든 개발자가 각자의 컴퓨터에서 수동으로 기초 데이터를 일일이 INSERT 해야 합니다.
    이런 반복 작업을 없애고, 어떤 개발 환경에서든 서버를 실행하기만 하면 항상 동일한 기초 데이터가 준비되도록 하여
    개발의 편의성과 일관성을 높이기 위해 구현
  - **멱등성(idempotency) 보장**
    - 멱등성이란? 어떤 연산을 여러 번 수행해도, 결과가 처음 한 번 수행했을 때와 똑같이 나오는 성질 
    - 각 데이터에 대해 ```if (platformRepository.count() == 0)``` 라는 조건을 넣었기 때문에
    존재 여부를 먼저 확인하여, 테이블이 비어있을 경우에만 초기화를 진행하도록 하여 멱등성을 보장

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="341" height="185" alt="image" src="https://github.com/user-attachments/assets/b8fc76ec-f643-49c9-80d5-fea35b7c80f8" />
