### PR TITLE
feat: 회원 정보 수정 기능

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
@@ -7,7 +7,7 @@ import com.likelion.bd.domain.influencer.web.dto.ActivityCreateRes;
 import com.likelion.bd.domain.user.entity.User;
 import com.likelion.bd.domain.user.repository.UserRepository;
 import com.likelion.bd.global.exception.CustomException;
-import com.likelion.bd.global.response.code.Influencer.ActivityErrorCode;
+import com.likelion.bd.global.response.code.Influencer.ActivityErrorResponseCode;
 import com.likelion.bd.global.response.code.UserErrorResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,7 +52,7 @@ public class InfluencerServiceImpl implements InfluencerService {
 
         for (Long platformId : activityCreateReq.getPlatformIds()) {
             Platform platform = platformRepository.findById(platformId)
-                    .orElseThrow(() -> new CustomException(ActivityErrorCode.PLATFORM_NOT_FOUND_404));
+                    .orElseThrow(() -> new CustomException(ActivityErrorResponseCode.PLATFORM_NOT_FOUND_404));
 
             ActivityPlatform ap = ActivityPlatform.builder()
                     .activity(activity)
@@ -64,7 +64,7 @@ public class InfluencerServiceImpl implements InfluencerService {
 
         for (Long contentTopicId : activityCreateReq.getContentTopicIds()) {
             ContentTopic contentTopic = contentTopicRepository.findById(contentTopicId)
-                    .orElseThrow(() -> new CustomException(ActivityErrorCode.CONTENTTOPIC_NOT_FOUND_404));
+                    .orElseThrow(() -> new CustomException(ActivityErrorResponseCode.CONTENTTOPIC_NOT_FOUND_404));
 
             ActivityContentTopic act = ActivityContentTopic.builder()
                     .activity(activity)
@@ -76,7 +76,7 @@ public class InfluencerServiceImpl implements InfluencerService {
 
         for (Long contentStyleId : activityCreateReq.getContentStyleIds()) {
             ContentStyle contentStyle = contentStyleRepository.findById(contentStyleId)
-                    .orElseThrow(() -> new CustomException(ActivityErrorCode.CONTENTSTYLE_NOT_FOUND_404));
+                    .orElseThrow(() -> new CustomException(ActivityErrorResponseCode.CONTENTSTYLE_NOT_FOUND_404));
 
             ActivityContentStyle acs = ActivityContentStyle.builder()
                     .activity(activity)
@@ -88,7 +88,7 @@ public class InfluencerServiceImpl implements InfluencerService {
 
         for (Long preferTopicId : activityCreateReq.getPreferTopicIds()) {
             PreferTopic preferTopic = preferTopicRepository.findById(preferTopicId)
-                    .orElseThrow(() -> new CustomException(ActivityErrorCode.PREPERTOPIC_NOT_FOUND_404));
+                    .orElseThrow(() -> new CustomException(ActivityErrorResponseCode.PREPERTOPIC_NOT_FOUND_404));
 
             ActivityPreferTopic apt = ActivityPreferTopic.builder()
                     .activity(activity)

--- a/bd/src/main/java/com/likelion/bd/domain/user/entity/User.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/entity/User.java
@@ -38,4 +38,16 @@ public class User extends BaseEntity {
     @Column(name = "ROLE", nullable = false)
     private UserRoleType role;
 
+    // -------------------------------------------------------------------------------------------------------
+
+    // 회원 정보 수정을 위한 메서드
+    public void updateProfile(String newNickname, String newImageUrl, String newIntroduction) {
+        if (newNickname != null) {
+            this.nickname = newNickname;
+        }
+
+        // 프로필 사진이랑 자기 소개글은 null 가능
+        this.profileImage = newImageUrl;
+        this.introduction = newIntroduction;
+    }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/repository/UserRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/repository/UserRepository.java
@@ -15,4 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // User 라는 객체가 존재하면 값을 담고, 존재하지 않으면 비어있는 상태로 반환
     Optional<User> findByEmail(String email);
+    Optional<User> findByUserId(Long userId);
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
@@ -15,4 +15,8 @@ public interface UserService {
 
     // 로그인
     UserSigninRes signin(UserSigninReq userSigninReq);
+
+    // 회원 정보 수정
+    void updateUser(UserUpdateReq userUpdateReq, Long userId);
+
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserServiceImpl.java
@@ -2,14 +2,13 @@ package com.likelion.bd.domain.user.service;
 
 import com.likelion.bd.domain.user.entity.User;
 import com.likelion.bd.domain.user.entity.UserRoleType;
-import com.likelion.bd.domain.user.exception.DuplicateEmailException;
-import com.likelion.bd.domain.user.exception.DuplicateNicknameException;
-import com.likelion.bd.domain.user.exception.InvalidPasswordException;
-import com.likelion.bd.domain.user.exception.NotFoundEmailException;
+import com.likelion.bd.domain.user.exception.*;
 import com.likelion.bd.domain.user.repository.UserRepository;
 import com.likelion.bd.domain.user.web.dto.*;
+import com.likelion.bd.global.exception.CustomException;
 import com.likelion.bd.global.external.s3.S3Service;
 import com.likelion.bd.global.jwt.JwtTokenProvider;
+import com.likelion.bd.global.response.code.UserErrorResponseCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -90,5 +89,41 @@ public class UserServiceImpl implements UserService {
         String token = jwtTokenProvider.createToken(user);
 
         return new UserSigninRes(token);
+    }
+
+    // 회원 정보 수정
+    @Override
+    @Transactional
+    public void updateUser(UserUpdateReq userUpdateReq, Long userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(UserErrorResponseCode.USER_NOT_FOUND_404));
+
+        String newNickname = null;
+        String newImageUrl = user.getProfileImage();
+        String newIntroduction = user.getIntroduction();
+
+        if (userUpdateReq.getNickname() != null && !userUpdateReq.getNickname().isEmpty()) {
+            newNickname = userUpdateReq.getNickname();
+        }
+
+        if (userUpdateReq.isImageDelete()) {
+            if (user.getProfileImage() != null) {
+                s3Service.deleteImageFromS3(user.getProfileImage());
+            }
+            newImageUrl = null;
+        }
+        if (userUpdateReq.getProfileImage() != null && !userUpdateReq.getProfileImage().isEmpty()) {
+            s3Service.deleteImageFromS3(user.getProfileImage());
+            newImageUrl = s3Service.uploadImageToS3(userUpdateReq.getProfileImage());
+        }
+
+        if (userUpdateReq.isIntroductionDelete()) {
+            newIntroduction = null;
+        }
+        if (userUpdateReq.getIntroduction() != null && !userUpdateReq.getIntroduction().isEmpty()) {
+            newIntroduction = userUpdateReq.getIntroduction();
+        }
+
+        user.updateProfile(newNickname, newImageUrl, newIntroduction);
     }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
@@ -2,11 +2,13 @@ package com.likelion.bd.domain.user.web.controller;
 
 import com.likelion.bd.domain.user.service.UserService;
 import com.likelion.bd.domain.user.web.dto.*;
+import com.likelion.bd.global.jwt.UserPrincipal;
 import com.likelion.bd.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -66,5 +68,19 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.ok(userSigninRes));
+    }
+
+    // 회원 정보 수정
+    @PutMapping("/update")
+    public ResponseEntity<SuccessResponse<?>> update(
+            @ModelAttribute @Valid UserUpdateReq userUpdateReq,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+
+        userService.updateUser(userUpdateReq, userPrincipal.getId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.emptyCustom("회원 정보 수정에 성공하셨습니다."));
     }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserUpdateReq.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserUpdateReq.java
@@ -1,0 +1,21 @@
+package com.likelion.bd.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserUpdateReq { // 프로필 수정은 전부 null 가능
+
+    // 3개 다 null 이면 -> 예전꺼 사용
+    private String nickname;
+    private MultipartFile profileImage;
+    private String introduction;
+
+    private boolean imageDelete; // 원래 있던 프로필 사진 없애고, 기본 프로필 사용하고 싶을 때
+    private boolean introductionDelete; // 원래 있던 설명글 없애고 싶을 때
+}

--- a/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers("/user/signup", "/user/signin",
                                 "/user/check-email", "/user/check-nickname").permitAll()
                         .requestMatchers("/influencer/create").hasRole("INFLUENCER")
+                        .requestMatchers("/influencer/update").authenticated()
 //                        .requestMatchers("/api/").permitAll()
 //                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()  // 그 외 요청은 전부 토큰 필요

--- a/bd/src/main/java/com/likelion/bd/global/response/code/Influencer/ActivityErrorResponseCode.java
+++ b/bd/src/main/java/com/likelion/bd/global/response/code/Influencer/ActivityErrorResponseCode.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum ActivityErrorCode implements BaseResponseCode {
+public enum ActivityErrorResponseCode implements BaseResponseCode {
 
     PLATFORM_NOT_FOUND_404("PLATFORM_NOT_FOUND_404",404,"해당 플랫폼이 존재하지 않습니다."),
     CONTENTTOPIC_NOT_FOUND_404("CONTENTTOPIC_NOT_FOUND_404",404,"해당 콘텐츠 분야가 존재하지 않습니다."),


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 인증된 사용자가 자신의 프로필 정보(닉네임, 프로필 사진, 자기소개)를 수정하는 기능을 구현

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] userId를 이용해 회원 정보 조회
- [x] 닉네임, 프로필 사진, 자기소개 수정 후 DB에 저장
- [x] 프로필 이미지 변경 또는 삭제 시, S3에 업로드된 기존 파일 삭제

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->

"Magic String" 문제를 해결하기 위한 DTO 설계 변경
- 초기 설계에서는 프로필 사진이나 자기소개를 삭제하기 위해 "delete"라는 특정 문자열을 받는 것으로 설계
- 하지만 이 방식은 사용자가 정말로 자기소개를 "delete" 라는 단어로 저장하고 싶을 때, 서버가 이를 삭제 명령으로 오해하여
  데이터를 유실시키는 문제(Magic String 문제) 존재

➡️ 해결: 이 문제를 해결하기 위해, 데이터와 명령 분리
- `profileImage`, `introduction` 필드는 데이터만 받음
- `imageDelete`, `introductionDelete` 라는 boolean 타입의 필드를 DTO에 추가하여 삭제 '명령' 을 전달 받게 함.

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
- 회원 정보 변경 전
<img width="1470" height="62" alt="image" src="https://github.com/user-attachments/assets/69e2a63d-4aef-4d29-bae7-f2d4bee44c4f" />

- 회원 정보 변경 후
<img width="1486" height="72" alt="image" src="https://github.com/user-attachments/assets/2a2822e9-55d5-4157-8333-1696d36e5c8d" />

---

<img width="542" height="224" alt="image" src="https://github.com/user-attachments/assets/b2b6a072-6f0d-42ae-92bb-dff86e5d44c0" />
