### PR TITLE
fix: 인플루언서 평점 관련 필드 및 조회 로직 추가

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Influencer.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Influencer.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -31,4 +32,10 @@ public class Influencer {
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "ACTIVITY_ID", unique = true, nullable = false)
     private Activity activity;
+
+    @Column(name = "total_score")
+    private Long totalScore;
+
+    @Column(name = "review_count")
+    private Long reviewCount;
 }

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
@@ -107,6 +107,8 @@ public class InfluencerServiceImpl implements InfluencerService {
         Influencer influencer = Influencer.builder()
                 .user(user)
                 .activity(activity)
+                .totalScore(0L)
+                .reviewCount(0L)
                 .build();
         influencerRepository.save(influencer);
 
@@ -140,11 +142,17 @@ public class InfluencerServiceImpl implements InfluencerService {
                 .map(apt -> apt.getPreferTopic().getName())
                 .toList();
 
+        double avgScore = 0.00;
+        if (influencer.getReviewCount() != 0) {
+            avgScore = (double) influencer.getTotalScore() / influencer.getReviewCount();
+        }
+
         return new InfluencerMyPageRes(
                 user.getProfileImage(),
                 activity.getActivityName(),
                 user.getName(),
                 activity.getFollowerCountRange().name(),
+                avgScore,
                 activity.getSnsUrl(),
                 activity.getMinAmount(),
                 platformDto,

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/InfluencerMyPageRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/InfluencerMyPageRes.java
@@ -7,6 +7,7 @@ public record InfluencerMyPageRes(
         String activityName,            // 활동명
         String nickName,                // 닉네임
         String follower,                // 팔로워 수
+        Double avgScore,                // 평점
         String snsUrl,                  // SNS 링크
         Long minAmount,                 // 희망하는 최소 금액
         List<String> platforms,        // 플랫폼 목록


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 인플루언서의 평균 평점을 계산하고 조회할 수 있는 평점 시스템의 핵심 기능을 구현

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] 평점 총합(totalScore)과 평가 횟수(reviewCount)를 저장할 필드를 추가
- [x] 신규 인플루언서 등록 시, 평점 관련 필드들을 기본값(0)으로 초기화
- [x] 마이페이지 조회 시, 저장된 평점 총합과 평가 횟수를 바탕으로 평균 평점을 계산해서 반환

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->
- X

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="193" height="39" alt="image" src="https://github.com/user-attachments/assets/c207cf79-a1b8-489a-a565-0a44732a2f80" />
