### PR TITLE
fix: 회원가입/프로필 생성 로직 분리

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/user/entity/User.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/entity/User.java
@@ -25,7 +25,7 @@ public class User extends BaseEntity {
     @Column(name = "PASSWORD", nullable = false)
     private String password;
 
-    @Column(name = "NICKNAME", nullable = false, unique = true)
+    @Column(name = "NICKNAME", unique = true)
     private String nickname;
 
     @Column(name = "PROFILE_IMAGE")

--- a/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/service/UserService.java
@@ -13,6 +13,9 @@ public interface UserService {
     // 회원 가입
     UserSignupRes signup(UserSignupReq userSignupReq);
 
+    // 프로필 생성
+    void profileCreate(ProfileCreateReq profileCreateReq);
+
     // 로그인
     UserSigninRes signin(UserSigninReq userSigninReq);
 

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
     // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<?>> signup(
-            @ModelAttribute @Valid UserSignupReq userSignupReq
+            @RequestBody @Valid UserSignupReq userSignupReq
     ) {
         // 서비스
         UserSignupRes userSignupRes = userService.signup(userSignupReq);
@@ -54,6 +54,20 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(SuccessResponse.ok(userSignupRes));
+    }
+
+    // 프로필 생성
+    @PostMapping("/profile")
+    public ResponseEntity<SuccessResponse<?>> profile(
+            @ModelAttribute @Valid ProfileCreateReq profileCreateReq
+    ) {
+        // 서비스
+        userService.profileCreate(profileCreateReq);
+
+        // 반환
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.emptyCustom("프로필 설정에 성공하셨습니다."));
     }
 
     // 로그인

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/dto/ProfileCreateReq.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/dto/ProfileCreateReq.java
@@ -1,0 +1,24 @@
+package com.likelion.bd.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProfileCreateReq {
+
+    @NotNull(message = "회원 ID는 필수 입력 값 입니다.")
+    private Long userId;
+
+    @NotBlank(message = "닉네임은 필수 입력 값 입니다.")
+    private String nickname;
+
+    private MultipartFile profileImage;
+
+    private String introduction;
+}

--- a/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserSignupReq.java
+++ b/bd/src/main/java/com/likelion/bd/domain/user/web/dto/UserSignupReq.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class UserSignupReq {
 
@@ -26,13 +25,6 @@ public class UserSignupReq {
             regexp = "^(?=.*[A-Za-z])(?=.*[^A-Za-z0-9]).{4,12}$",
             message = "비밀번호는 영문자와 특수문자를 포함하여 4~12자여야 합니다.")
     private String password;
-
-    @NotBlank(message = "닉네임은 필수 입력 값 입니다.")
-    private String nickname;
-
-    private MultipartFile profileImage;
-
-    private String introduction;
 
     @NotBlank(message = "역할은 필수 입력 값입니다.")
     @Pattern(regexp = "^(business|influencer)$", message = "역할은 'business' 또는 'influencer' 중 하나여야 합니다.")

--- a/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
 
-                        .requestMatchers("/user/signup", "/user/signin",
+                        .requestMatchers("/user/signup", "/user/profile", "/user/signin",
                                 "/user/check-email", "/user/check-nickname").permitAll()
                         .requestMatchers("/influencer/create", "/influencer/mypage").hasRole("INFLUENCER")
                         .requestMatchers("/influencer/update").authenticated()


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 기존 회원가입 절차에 포함되어 있던 프로필 생성을 별도의 기능으로 분리하고, 해당 API를 구현

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] 기존의 통합된 회원가입 로직에서 프로필을 생성하는 부분을 별도의 서비스로 분리
- [x] 로직 변경에 따라, 회원가입 시 닉네임이 null일 수 있도록 User 엔티티의 제약조건을 수정

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->
- X

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="724" height="268" alt="image" src="https://github.com/user-attachments/assets/af945259-534f-4888-8c9f-bffed581c14c" />
<img width="357" height="153" alt="image" src="https://github.com/user-attachments/assets/089240a5-a9d3-4cb5-a3ea-3e428af088b7" />
