### PR TITLE
feature: 제안서 폼 조회 기능

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/campaign/service/ProposalService.java
+++ b/bd/src/main/java/com/likelion/bd/domain/campaign/service/ProposalService.java
@@ -1,10 +1,14 @@
 package com.likelion.bd.domain.campaign.service;
 
+import com.likelion.bd.domain.campaign.web.dto.ProposalFormRes;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteReq;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteRes;
 import com.likelion.bd.global.jwt.UserPrincipal;
 
 public interface ProposalService {
+
+    // 제안서 작성/수정할 때 주어지는 정보들
+    ProposalFormRes getProposalForm(UserPrincipal userPrincipal);
 
     // 제안서 작성/수정
     ProposalWriteRes writeProposal(ProposalWriteReq proposalWriteReq, UserPrincipal userPrincipal);

--- a/bd/src/main/java/com/likelion/bd/domain/campaign/service/ProposalServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/campaign/service/ProposalServiceImpl.java
@@ -1,23 +1,86 @@
 package com.likelion.bd.domain.campaign.service;
 
+import com.likelion.bd.domain.businessman.entity.BusinessMan;
+import com.likelion.bd.domain.businessman.repository.BusinessManRepository;
 import com.likelion.bd.domain.campaign.entity.Proposal;
 import com.likelion.bd.domain.campaign.repository.ProposalRepository;
+import com.likelion.bd.domain.campaign.web.dto.ProposalFormRes;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteReq;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteRes;
+import com.likelion.bd.domain.influencer.entity.Influencer;
+import com.likelion.bd.domain.influencer.repository.InfluencerRepository;
 import com.likelion.bd.domain.user.entity.UserRoleType;
+import com.likelion.bd.global.exception.CustomException;
 import com.likelion.bd.global.jwt.UserPrincipal;
-import jakarta.transaction.Transactional;
+import com.likelion.bd.global.response.code.Influencer.InfluencerErrorResponseCode;
+import com.likelion.bd.global.response.code.businessMan.BusinessManErrorResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ProposalServiceImpl implements ProposalService {
 
+    private final BusinessManRepository businessManRepository;
+    private final InfluencerRepository influencerRepository;
     private final ProposalRepository proposalRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProposalFormRes getProposalForm(UserPrincipal userPrincipal) {
+
+        ProposalFormRes.DefaultInfo defaultInfo;
+
+        if (UserRoleType.valueOf(userPrincipal.getRole()) == UserRoleType.BUSINESS) { // 자영업자
+            BusinessMan businessMan = businessManRepository.findByUserUserId(userPrincipal.getId())
+                    .orElseThrow(() -> new CustomException(BusinessManErrorResponseCode.BUSINESSMAN_NOT_FOUND_404));
+
+            defaultInfo = new ProposalFormRes.BusinessManInfo(
+                    businessMan.getUser().getName(),
+                    businessMan.getWorkPlace().getName(),
+                    businessMan.getWorkPlace().getAddress()
+            );
+        } else { // 인플루언서
+            Influencer influencer = influencerRepository.findByUserUserId(userPrincipal.getId())
+                    .orElseThrow(() -> new CustomException(InfluencerErrorResponseCode.INFLUENCER_NOT_FOUND_404));
+
+            List<String> platforms = influencer.getActivity().getActivityPlatformList().stream()
+                    .map(ap -> ap.getPlatform().getName())
+                    .toList();
+
+            defaultInfo = new ProposalFormRes.InfluencerInfo(
+                    influencer.getUser().getName(),
+                    influencer.getActivity().getActivityName(),
+                    platforms
+            );
+        }
+
+        Optional<Proposal> optionalProposal = proposalRepository.findByWriterId(userPrincipal.getId());
+
+        Optional<ProposalFormRes.ExistInfo> existInfo = optionalProposal.
+                map(proposal -> {
+                    String contentTopic =
+                            (UserRoleType.valueOf(userPrincipal.getRole()) == UserRoleType.INFLUENCER)
+                                    ? proposal.getContentTopic() : null;
+
+                    return new ProposalFormRes.ExistInfo(
+                            proposal.getTitle(),
+                            proposal.getOfferAmount(),
+                            proposal.getStartDate().toString(),
+                            proposal.getEndDate().toString(),
+                            proposal.getOverView(),
+                            proposal.getRequest(),
+                            contentTopic
+                    );
+                });
+
+        return new ProposalFormRes(defaultInfo, existInfo);
+    }
 
     @Override
     @Transactional
@@ -59,4 +122,5 @@ public class ProposalServiceImpl implements ProposalService {
 
         return new ProposalWriteRes(proposal.getProposalId());
     }
+
 }

--- a/bd/src/main/java/com/likelion/bd/domain/campaign/web/controller/ProposalController.java
+++ b/bd/src/main/java/com/likelion/bd/domain/campaign/web/controller/ProposalController.java
@@ -1,6 +1,7 @@
 package com.likelion.bd.domain.campaign.web.controller;
 
 import com.likelion.bd.domain.campaign.service.ProposalService;
+import com.likelion.bd.domain.campaign.web.dto.ProposalFormRes;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteReq;
 import com.likelion.bd.domain.campaign.web.dto.ProposalWriteRes;
 import com.likelion.bd.global.jwt.UserPrincipal;
@@ -10,10 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/proposal")
@@ -21,6 +19,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProposalController {
 
     private final ProposalService proposalService;
+
+    @GetMapping("write")
+    public ResponseEntity<SuccessResponse<?>> getForm(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+
+        ProposalFormRes proposalFormRes = proposalService.getProposalForm(userPrincipal);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.ok(proposalFormRes));
+    }
 
     @PostMapping("write")
     public ResponseEntity<SuccessResponse<?>> write(

--- a/bd/src/main/java/com/likelion/bd/domain/campaign/web/dto/ProposalFormRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/campaign/web/dto/ProposalFormRes.java
@@ -1,0 +1,38 @@
+package com.likelion.bd.domain.campaign.web.dto;
+
+import java.util.List;
+import java.util.Optional;
+
+public record ProposalFormRes(
+        // 기본 정보 필드
+        DefaultInfo defaultInfo,
+        // 기존 제안서 정보 (Optional), 있을 수도 없을 수도
+        Optional<ExistInfo> existInfo
+) {
+
+    public interface DefaultInfo {
+        String name(); // 실제 이름
+    }
+
+    public record BusinessManInfo(
+            String name,
+            String workPlaceName,
+            String workPlaceAddress
+    ) implements DefaultInfo {}
+
+    public record InfluencerInfo(
+            String name,
+            String activityName,
+            List<String> platforms
+    ) implements DefaultInfo {}
+
+    public record ExistInfo(
+            String title,
+            Long offerAmount,
+            String startDate,
+            String endDate,
+            String overView,
+            String request,
+            String contentTopic // 인플루언서 전용 필드 (자영업자일 경우 null)
+    ) {}
+}

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/service/InfluencerServiceImpl.java
@@ -255,16 +255,16 @@ public class InfluencerServiceImpl implements InfluencerService {
         User user = influencer.getUser();
         Activity activity = influencer.getActivity();
 
-        List<String> platformDto = activity.getActivityPlatformList().stream()
+        List<String> platforms = activity.getActivityPlatformList().stream()
                 .map(ap -> ap.getPlatform().getName())
                 .toList();
-        List<String> contentTopicDto = activity.getActivityContentTopicList().stream()
+        List<String> contentTopics = activity.getActivityContentTopicList().stream()
                 .map(act -> act.getContentTopic().getName())
                 .toList();
-        List<String> contentStyleDto = activity.getActivityContentStyleList().stream()
+        List<String> contentStyles = activity.getActivityContentStyleList().stream()
                 .map(acs -> acs.getContentStyle().getName())
                 .toList();
-        List<String> preferTopicDto = activity.getActivityPreferTopicList().stream()
+        List<String> preferTopics = activity.getActivityPreferTopicList().stream()
                 .map(apt -> apt.getPreferTopic().getName())
                 .toList();
 
@@ -288,10 +288,10 @@ public class InfluencerServiceImpl implements InfluencerService {
                 influencer.getReviewCount(),
                 activity.getSnsUrl(),
                 activity.getMinAmount(),
-                platformDto,
-                contentTopicDto,
-                contentStyleDto,
-                preferTopicDto
+                platforms,
+                contentTopics,
+                contentStyles,
+                preferTopics
         );
     }
 }

--- a/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/influencer/mypage").hasRole("INFLUENCER")
                         // 캠페인
                         .requestMatchers("/api/campaigns").hasAnyRole("BUSINESS","INFLUENCER")
+                        .requestMatchers(HttpMethod.GET, "/api/proposal/write").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/proposal/write").authenticated()
                         .anyRequest().authenticated()  // 그 외 요청은 전부 토큰 필요
                 );


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 사용자가 제안서를 작성하거나 수정할 때 필요한 초기 데이터를 제공하는 API 기능을 구현 

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] 통합 응답 DTO 설계
- [x] 제안서 폼 조회 로직 구현(역할 및 제안서 존재 유무에 따른 분기 처리)

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->

**유연한 DTO 설계를 통한 다중 케이스 처리**
1. 사용자 역할이 자영업자일 때 vs 인플루언서일 때
2. 기존에 작성한 제안서가 없을 때 vs 있을 때

-> 이 문제를 해결하기 위해, 응답 DTO(ProposalFormRes)를 다음과 같이 여러 레코드를 조합하는 방식으로 설계
  - 인터페이스를 이용한 역할별 데이터 분리
    - DefaultInfo라는 공통 인터페이스를 먼저 정의했습니다.
    - 자영업자용 기본 정보(BusinessManInfo)와 인플루언서용 기본 정보(InfluencerInfo)를 각각의 Record로 만들고, 
  DefaultInfo 인터페이스를 구현
  - 이를 통해 서비스 로직에서는 사용자의 역할에 따라 적절한 Record 객체(BusinessManInfo 또는 InfluencerInfo)를 생성하여 반환하면, JSON으로 변환될 때 자동으로 해당 역할에 맞는 구조의 데이터가 포함

- Optional을 이용한 조건부 데이터 처리
  - 기존에 작성한 제안서 정보는 있을 수도, 없을 수도 있기 때문에 `Optional<ExistInfo>` 타입으로 필드를 선언

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="334" height="353" alt="image" src="https://github.com/user-attachments/assets/6be9ee0a-9f8c-4ef5-ab51-b790eb804576" />
<img width="464" height="492" alt="image" src="https://github.com/user-attachments/assets/8eea1c65-2a0f-446c-a602-02285ab4664b" />
