### PR TITLE
feat: 홈 화면 조회 시, 정보 추가

### DIFF
--- a/bd/src/main/java/com/likelion/bd/domain/businessman/entity/BusinessMan.java
+++ b/bd/src/main/java/com/likelion/bd/domain/businessman/entity/BusinessMan.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Entity
 @Getter
 @Builder
@@ -33,6 +36,17 @@ public class BusinessMan extends BaseEntity {
 
     @Column(name = "review_count")
     private Long reviewCount;
+
+    public String formatAverageScore(Double totalScore, Long reviewCount) {
+        //소수점 2자리까지 처리한다.
+        BigDecimal avgScore = BigDecimal.ZERO;
+        if (reviewCount > 0) {
+            avgScore = BigDecimal.valueOf(totalScore)
+                    .divide(BigDecimal.valueOf(reviewCount), 2, RoundingMode.HALF_UP);
+        }
+
+        return String.format("%.2f", avgScore);
+    }
 
     public void addReview(Double score) {
         this.totalScore += score;

--- a/bd/src/main/java/com/likelion/bd/domain/businessman/repository/BusinessManRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/businessman/repository/BusinessManRepository.java
@@ -2,11 +2,17 @@ package com.likelion.bd.domain.businessman.repository;
 
 import com.likelion.bd.domain.businessman.entity.BusinessMan;
 import com.likelion.bd.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BusinessManRepository extends JpaRepository<BusinessMan, Long> {
     Optional<BusinessMan> findByUser(User user);
     Optional<BusinessMan> findByUserUserId(Long userId);
+
+    @Query("SELECT b FROM BusinessMan b WHERE b.reviewCount > 0 ORDER BY (b.totalScore / b.reviewCount) DESC")
+    List<BusinessMan> findTopBusinessManAverageScoreDesc(Pageable pageable);
 }

--- a/bd/src/main/java/com/likelion/bd/domain/businessman/service/BusinessManServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/businessman/service/BusinessManServiceImpl.java
@@ -3,6 +3,8 @@ package com.likelion.bd.domain.businessman.service;
 import com.likelion.bd.domain.businessman.entity.*;
 import com.likelion.bd.domain.businessman.repository.*;
 import com.likelion.bd.domain.businessman.web.dto.*;
+import com.likelion.bd.domain.influencer.entity.Influencer;
+import com.likelion.bd.domain.influencer.repository.InfluencerRepository;
 import com.likelion.bd.domain.user.entity.User;
 import com.likelion.bd.domain.user.repository.UserRepository;
 import com.likelion.bd.global.exception.CustomException;
@@ -11,6 +13,8 @@ import com.likelion.bd.global.response.code.businessMan.BusinessManErrorResponse
 import com.likelion.bd.global.response.code.user.UserErrorResponseCode;
 import com.likelion.bd.global.response.code.businessMan.WorkPlaceErrorReponseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +34,7 @@ public class BusinessManServiceImpl implements BusinessManService {
     private final MoodRepository moodRepository;
     private final PromotionRepository promotionRepository;
     private final BusinessManRepository businessManRepository;
+    private final InfluencerRepository influencerRepository;
 
     @Transactional
     @Override
@@ -240,23 +245,27 @@ public class BusinessManServiceImpl implements BusinessManService {
                 .orElseThrow(()->new CustomException(BusinessManErrorResponseCode.BUSINESSMAN_NOT_FOUND_404));
 
         User user = businessMan.getUser();
-
         WorkPlace workPlace = businessMan.getWorkPlace();
+        String avgText = businessMan.formatAverageScore(businessMan.getTotalScore(), businessMan.getReviewCount());
 
-        //소수점 2자리까지 처리한다.
-        BigDecimal avgScore = BigDecimal.ZERO;
-        if (businessMan.getReviewCount() > 0) {
-            avgScore = BigDecimal.valueOf(businessMan.getTotalScore())
-                    .divide(BigDecimal.valueOf(businessMan.getReviewCount()), 2, RoundingMode.HALF_UP);
-        }
-        String avgText = String.format("%.2f", avgScore);
+        Pageable topFour = PageRequest.of(0, 4);
+        List<Influencer> topInfluencers = influencerRepository.findTopInfluencerFollowerCountDesc(topFour);
+        List<BusinessHomeRes.InfluencerSummaryRes> Influencers = topInfluencers.stream()
+                .map(Influencer -> new BusinessHomeRes.InfluencerSummaryRes(
+                        Influencer.getUser().getUserId(),
+                        Influencer.getUser().getNickname(),
+                        Influencer.getUser().getProfileImage(),
+                        Influencer.getActivity().formatFollowers()
+                ))
+                .toList();
 
         return new BusinessHomeRes(
                 user.getProfileImage(),
                 user.getNickname(),
                 workPlace.getName(),
                 avgText,
-                businessMan.getReviewCount()
+                businessMan.getReviewCount(),
+                Influencers
         );
     }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/businessman/web/dto/BusinessHomeRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/businessman/web/dto/BusinessHomeRes.java
@@ -1,10 +1,21 @@
 package com.likelion.bd.domain.businessman.web.dto;
 
+import java.util.List;
+
 public record BusinessHomeRes(
         String imgUrl,
         String nickname,
         String workPlaceName,
         String avgScore,
-        Long reviewCount
+        Long reviewCount,
+        List<InfluencerSummaryRes> Influencers
 ) {
+    public record InfluencerSummaryRes(
+            Long InfluencerId,
+            String nickName,
+            String imgUrl,
+            String follower
+    ) {
+
+    }
 }

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Influencer.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/entity/Influencer.java
@@ -6,7 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Entity
 @Getter
@@ -38,6 +40,17 @@ public class Influencer {
 
     @Column(name = "review_count")
     private Long reviewCount;
+
+    public String formatAverageScore(Double totalScore, Long reviewCount) {
+        //소수점 2자리까지 처리한다.
+        BigDecimal avgScore = BigDecimal.ZERO;
+        if (reviewCount > 0) {
+            avgScore = BigDecimal.valueOf(totalScore)
+                    .divide(BigDecimal.valueOf(reviewCount), 2, RoundingMode.HALF_UP);
+        }
+
+        return String.format("%.2f", avgScore);
+    }
 
     public void addReview(Double score) {
         this.totalScore += score;

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/repository/InfluencerRepository.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/repository/InfluencerRepository.java
@@ -1,11 +1,17 @@
 package com.likelion.bd.domain.influencer.repository;
 
 import com.likelion.bd.domain.influencer.entity.Influencer;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InfluencerRepository extends JpaRepository<Influencer, Long> {
 
     Optional<Influencer> findByUserUserId(Long userId);
+
+    @Query("SELECT i FROM Influencer i ORDER BY i.activity.followerCount DESC")
+    List<Influencer> findTopInfluencerFollowerCountDesc(Pageable pageable);
 }

--- a/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/InfluencerHomeRes.java
+++ b/bd/src/main/java/com/likelion/bd/domain/influencer/web/dto/InfluencerHomeRes.java
@@ -1,13 +1,24 @@
 package com.likelion.bd.domain.influencer.web.dto;
 
+import java.util.List;
+
 public record InfluencerHomeRes(
         String imgUrl,
         String nickName,
         String activityName,
         String avgScore,
-        Long reviewCount
+        Long reviewCount,
+        List<BusinessManSummaryRes> businessMans
 ) {
+    public record BusinessManSummaryRes(
+            Long businessManId,
+            String nickName,
+            String imgUrl,
+            String avgScore,
+            Long reviewCount
+    ) {
 
+    }
 }
 
 /*

--- a/bd/src/main/java/com/likelion/bd/domain/match/service/MatchServiceImpl.java
+++ b/bd/src/main/java/com/likelion/bd/domain/match/service/MatchServiceImpl.java
@@ -67,7 +67,7 @@ public class MatchServiceImpl implements MatchService {
         long sumReviews = 0L, sumScores = 0L; // totalScore는 5점 만점 "합계" 가정
         for (Influencer i : influencerList) {
             long rc = reviewCountOf(i);
-            Long ts = totalScoreOf(i);
+            Double ts = totalScoreOf(i);
             if (rc > 0 && ts != null) {
                 sumReviews += rc;
                 sumScores += ts;
@@ -214,7 +214,7 @@ public class MatchServiceImpl implements MatchService {
      */
     private double avgRating01Of(Influencer influencer) {
         long rc = reviewCountOf(influencer);
-        Long ts = totalScoreOf(influencer);
+        Double ts = totalScoreOf(influencer);
         if (rc <= 0 || ts == null) return 0.5;
         double avg5 = ((double) ts) / rc;
         double v = avg5 / 5.0;
@@ -224,7 +224,7 @@ public class MatchServiceImpl implements MatchService {
     /**
      * 평균 평점 문자열(소수 2자리). 리뷰 0이면 "0.00"
      */
-    private String formatAvgScore(Long totalScore, long reviewCount) {
+    private String formatAvgScore(Double totalScore, long reviewCount) {
         if (reviewCount <= 0 || totalScore == null) return "0.00";
         double avg5 = ((double) totalScore) / reviewCount; // 5점 만점 평균
         return new DecimalFormat("0.00").format(avg5);
@@ -241,7 +241,7 @@ public class MatchServiceImpl implements MatchService {
     /**
      * 합계 평점(5점 만점 합계) — 없으면 null
      */
-    private Long totalScoreOf(Influencer influencer) {
+    private Double totalScoreOf(Influencer influencer) {
         return influencer.getTotalScore();
     }
 

--- a/bd/src/main/java/com/likelion/bd/global/config/WebConfig.java
+++ b/bd/src/main/java/com/likelion/bd/global/config/WebConfig.java
@@ -9,9 +9,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-//                .allowedOrigins() // 특정 도메인 http://localhost:3000, http://likelion.com
-                .allowedOriginPatterns("*") // 여러 패턴이 필요할 때
+                .allowedOrigins("http://localhost:5173", "https://b-d-frontend.vercel.app")
+//                .allowedOriginPatterns("*") // 여러 패턴이 필요할 때
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type")
                 .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 이 PR에서 어떤 작업을 했는지를 제목보다는 더 구체적으로 적어주세요.
     예: '사용자 회원가입 시 이메일 중복을 검사하는 기능을 구현' -->
- 홈 화면에 표시될 인플루언서 및 자영업자 정보들 추가 반환

## 📝 작업 내용
<!-- 어떤 걸 작업했는지 간단히 적어주세요.
     코드에서 수정한 주요 포인트나 추가한 기능 위주로 작성하면 됩니다. -->
- [x] 인플루언서 랭킹 로직 추가
- [x] 자영업자 랭킹 로직 추가
- [x] Long -> Double 타입 변환
- [x] WebConfig 수정

## 📎 참고 사항
<!-- 코드 리뷰어나 팀원이 참고하면 좋을 사항이 있다면 여기에 작성해주세요.
    예)
     - 작업하면서 새로 알게 된 점이나 느낀 점
     - 고민했던 부분이나 우려되는 점
     - 팀원과 논의하고 싶은 내용
     - 로직이나 구조 관련해서 알아두면 좋은 점
     - 참고한 문서, 블로그, 노션 링크 등 (있다면 함께 공유해주세요) -->
- 홈 화면 다른 사용자 정보 반환을 위해 Repository에 추가된 JPQL 쿼리
  - 자영업자 (평점 순): 리뷰가 1개 이상인 사용자를 대상으로, 평균 리뷰 점수가 높은 순으로 정렬
  ```@Query("SELECT b FROM BusinessMan b WHERE b.reviewCount > 0 ORDER BY (b.totalScore / b.reviewCount) DESC")```
  - 인플루언서 (팔로워 순): 팔로워 수가 많은 순으로 정렬
  ```@Query("SELECT i FROM Influencer i ORDER BY i.activity.followerCount DESC")```

##  🖼️ 사진
<!-- 필요한 경우에만 이미지나 스크린샷을 첨부해주세요. -->
<img width="518" height="602" alt="image" src="https://github.com/user-attachments/assets/b99f853e-8ed1-44e8-9271-7bc4b058ad44" />
<img width="530" height="625" alt="image" src="https://github.com/user-attachments/assets/6df9d95c-bfb9-4aca-ac2a-1cdd4e1fd2fc" />
